### PR TITLE
implement multiple message types as list #163

### DIFF
--- a/_examples/axon-avro-holi-bank-example/src/main/avro/BankAccountContext.avpr
+++ b/_examples/axon-avro-holi-bank-example/src/main/avro/BankAccountContext.avpr
@@ -249,7 +249,7 @@
       "doc": "Creates a new bank account.",
       "meta": {
         "group": "BankAccountAggregate",
-        "type": "deciderInit"
+        "types": [ "decider", "factory" ]
       },
       "request": [
         {
@@ -265,7 +265,7 @@
     "withdrawMoney": {
       "meta": {
         "group": "BankAccountAggregate",
-        "type": "decider"
+        "types": ["decider"]
       },
       "request": [
         {
@@ -278,7 +278,7 @@
     "depositMoney": {
       "meta": {
         "group": "BankAccountAggregate",
-        "type": "decider"
+        "types": ["decider"]
       },
       "request": [
         {
@@ -293,7 +293,7 @@
     "findCurrentBalanceForAccountId": {
       "meta": {
         "group": "BankAccountProjection",
-        "type": "query"
+        "types": ["query"]
       },
       "request": [
         {
@@ -309,7 +309,7 @@
     "findAllMoneyTransfersForAccountId": {
       "meta": {
         "group": "BankAccountProjection",
-        "type": "query"
+        "types": ["query"]
       },
       "request": [
         {

--- a/axon-avro-generation/src/main/kotlin/meta/MessageMetaData.kt
+++ b/axon-avro-generation/src/main/kotlin/meta/MessageMetaData.kt
@@ -1,6 +1,6 @@
 package io.holixon.axon.avro.generation.meta
 
-import io.holixon.axon.avro.generation.meta.FieldMetaData.Companion.KEYS.TYPE
+import io.holixon.axon.avro.generation.meta.MessageMetaData.Companion.KEYS.TYPES
 import io.holixon.axon.avro.generation.meta.MessageMetaData.Companion.KEYS.GROUP
 import io.toolisticon.kotlin.avro.model.wrapper.AvroProtocol
 import io.toolisticon.kotlin.avro.value.Name
@@ -11,12 +11,12 @@ import io.toolisticon.kotlin.avro.value.property.meta
  */
 data class MessageMetaData(
   val group: Name?,
-  val type: MessageMetaDataType?
+  val types: List<MessageMetaDataType>?
 ) : AxonAvroMetaData {
   companion object {
     object KEYS {
       const val GROUP = "group"
-      const val TYPE = "type"
+      const val TYPES = "types"
     }
 
     /**
@@ -25,7 +25,7 @@ data class MessageMetaData(
     fun AvroProtocol.Message.messageMetaData(): MessageMetaData? = this.properties.meta.metaData {
       MessageMetaData(
         group = this[GROUP]?.let { it as String }?.let { Name(it.trim()) },
-        type = this[TYPE]?.let { it as String }?.let { MessageMetaDataType[it.trim()] }
+        types = this[TYPES]?.let { types -> types as List<String> }?.mapNotNull { type -> MessageMetaDataType[type.trim()] }
       )
     }
   }

--- a/axon-avro-generation/src/main/kotlin/meta/MessageMetaDataType.kt
+++ b/axon-avro-generation/src/main/kotlin/meta/MessageMetaDataType.kt
@@ -8,7 +8,7 @@ import java.util.*
  */
 enum class MessageMetaDataType {
   Decider,
-  DeciderInit,
+  Factory,
   Query;
 
   val decapitalizedName = name.replaceFirstChar { c -> c.lowercase(Locale.getDefault()) }

--- a/axon-avro-generation/src/main/kotlin/strategy/AxonCommandHandlerProtocolInterfaceStrategy.kt
+++ b/axon-avro-generation/src/main/kotlin/strategy/AxonCommandHandlerProtocolInterfaceStrategy.kt
@@ -2,7 +2,6 @@ package io.holixon.axon.avro.generation.strategy
 
 import _ktx.StringKtx.firstUppercase
 import com.squareup.kotlinpoet.*
-import io.holixon.axon.avro.generation.meta.AxonAvroMetaData.Companion.metaData
 import io.holixon.axon.avro.generation.meta.FieldMetaData.Companion.fieldMetaData
 import io.holixon.axon.avro.generation.meta.FieldMetaDataType
 import io.holixon.axon.avro.generation.meta.MessageMetaData.Companion.messageMetaData
@@ -22,7 +21,6 @@ import io.toolisticon.kotlin.generation.KotlinCodeGeneration.buildAnnotation
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.builder
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.builder.funBuilder
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.builder.objectBuilder
-import io.toolisticon.kotlin.generation.builder.KotlinAnnotationSpecBuilder.Companion.member
 import io.toolisticon.kotlin.generation.builder.KotlinFunSpecBuilder
 import io.toolisticon.kotlin.generation.spec.KotlinFileSpec
 import io.toolisticon.kotlin.generation.spi.processor.executeAll
@@ -59,7 +57,7 @@ class AxonCommandHandlerProtocolInterfaceStrategy : AvroFileSpecFromProtocolDecl
     Single interface for each command
      */
     input.protocol.messages
-      .filterValues { message -> message.isDecider() || message.isDeciderInit() }
+      .filterValues { message -> message.isDecider() }
       .entries
       .groupBy { message -> message.value.messageMetaData()?.group?.value ?: UNKNOWN_GROUP }
       .mapNotNull { (groupName, messages) ->
@@ -128,7 +126,7 @@ class AxonCommandHandlerProtocolInterfaceStrategy : AvroFileSpecFromProtocolDecl
         addAnnotation(CommandHandler::class)
         addParameter(command.name.value, avroPoetTypes[command.schema.hashCode].typeName)
 
-        if (message.isDeciderInit()) {
+        if (message.isFactory()) {
           addAnnotation(
             buildAnnotation(CreationPolicy::class) {
               addEnumMember("value", AggregateCreationPolicy.ALWAYS)
@@ -149,6 +147,6 @@ class AxonCommandHandlerProtocolInterfaceStrategy : AvroFileSpecFromProtocolDecl
   override fun test(context: ProtocolDeclarationContext, input: Any): Boolean {
     return super.test(context, input)
       && input is ProtocolDeclaration
-      && input.protocol.messages.values.any { message -> message.isDecider() || message.isDeciderInit() }
+      && input.protocol.messages.values.any { message -> message.isDecider() || message.isFactory() }
   }
 }

--- a/axon-avro-generation/src/main/kotlin/strategy/AxonEventSourcingHandlerProtocolInterfaceStrategy.kt
+++ b/axon-avro-generation/src/main/kotlin/strategy/AxonEventSourcingHandlerProtocolInterfaceStrategy.kt
@@ -51,7 +51,7 @@ class AxonEventSourcingHandlerProtocolInterfaceStrategy : AvroFileSpecFromProtoc
     Single interface for each event souring handler
      */
     input.protocol.messages.filterTwoWay()
-      .filterValues { message -> message.isDecider() || message.isDeciderInit() }
+      .filterValues { message -> message.isDecider() || message.isFactory() }
       .entries
       .groupBy { message -> message.value.messageMetaData()?.group?.value ?: UNKNOWN_GROUP }
       .mapNotNull { (groupName, messages) ->
@@ -107,6 +107,6 @@ class AxonEventSourcingHandlerProtocolInterfaceStrategy : AvroFileSpecFromProtoc
   override fun test(context: ProtocolDeclarationContext, input: Any): Boolean {
     return super.test(context, input)
       && input is ProtocolDeclaration
-      && input.protocol.messages.values.any { message -> message.isDecider() || message.isDeciderInit() }
+      && input.protocol.messages.values.any { message -> message.isDecider() || message.isFactory() }
   }
 }

--- a/axon-avro-generation/src/main/kotlin/strategy/AxonExtensions.kt
+++ b/axon-avro-generation/src/main/kotlin/strategy/AxonExtensions.kt
@@ -24,15 +24,15 @@ fun AvroProtocol.Message.isQuery(): Boolean {
       .any { RecordMetaDataType.Query == it.type }
     // TODO: analyze response of query
    */
-  return this.messageMetaData()?.type == MessageMetaDataType.Query
+  return this.messageMetaData()?.types?.contains(MessageMetaDataType.Query) ?: false
 }
 
 fun AvroProtocol.Message.isDecider(): Boolean {
-  return this.messageMetaData()?.type == MessageMetaDataType.Decider
+  return this.messageMetaData()?.types?.contains(MessageMetaDataType.Decider) ?: false
 }
 
-fun AvroProtocol.Message.isDeciderInit(): Boolean {
-  return this.messageMetaData()?.type == MessageMetaDataType.DeciderInit
+fun AvroProtocol.Message.isFactory(): Boolean {
+  return this.messageMetaData()?.types?.contains(MessageMetaDataType.Factory) ?: false
 }
 
 


### PR DESCRIPTION
Instead of `message.type` containing a single value now support `message.types` containing a list of values.

Valid values for current strategies are:

- `query`
- `decider`
- `factory` - special marker for the decider delivering the aggregate (factory decider)


